### PR TITLE
Fix: Correct zeroing logic in ScaleViewModel

### DIFF
--- a/TrackWeight/ScaleViewModel.swift
+++ b/TrackWeight/ScaleViewModel.swift
@@ -16,6 +16,7 @@ final class ScaleViewModel: ObservableObject {
     
     private let manager = OMSManager.shared
     private var task: Task<Void, Never>?
+    private var rawWeight: Float = 0.0
     
     func startListening() {
         if manager.startListening() {
@@ -42,7 +43,7 @@ final class ScaleViewModel: ObservableObject {
     
     func zeroScale() {
         if hasTouch {
-            zeroOffset = currentWeight + zeroOffset
+            zeroOffset = rawWeight
         }
     }
     
@@ -53,7 +54,7 @@ final class ScaleViewModel: ObservableObject {
             zeroOffset = 0.0  // Reset zero when finger is lifted
         } else {
             hasTouch = true
-            let rawWeight = touchData.first?.pressure ?? 0.0
+            rawWeight = touchData.first?.pressure ?? 0.0
             currentWeight = max(0, rawWeight - zeroOffset)
         }
     }


### PR DESCRIPTION
This pull request addresses a logic flaw in the ScaleViewModel that caused incorrect weight
  measurements when the "Zero Scale" button was used multiple times without lifting the finger from the
  trackpad.

  #### The Problem:

  The previous implementation of the zeroScale() function would continuously add the currentWeight to
  the zeroOffset. This cumulative effect resulted in an incorrect zeroOffset and, consequently,
  inaccurate weight readings after the first zeroing action.

   ####  The Solution:

  The zeroScale() function has been updated to set the zeroOffset to the current raw weight reading
  from the trackpad. This ensures that each time the scale is zeroed, it correctly calibrates to the
  current pressure, regardless of previous zeroing actions.

   #### Changes Made:

   1. Introduced `rawWeight`: A new private property, rawWeight, was added to ScaleViewModel to store the
      unprocessed pressure value from the trackpad.
   2. Updated `processTouchData(_:)`: This function now populates rawWeight with the latest pressure data
      and calculates currentWeight based on the rawWeight and zeroOffset.
   3. Corrected `zeroScale()`: The function now sets zeroOffset directly to the current rawWeight, fixing
      the cumulative offset bug.

  This fix ensures that the zeroing functionality is reliable and produces accurate and repeatable
  weight measurements as intended.