### PR TITLE
zeroOffset

### DIFF
--- a/TrackWeight/ScaleView.swift
+++ b/TrackWeight/ScaleView.swift
@@ -77,33 +77,57 @@ struct ScaleView: View {
                                     .foregroundStyle(.gray)
                             }
                             
-                            Button(action: {
-                                viewModel.zeroScale()
-                            }) {
-                                HStack(spacing: 8) {
-                                    Image(systemName: "arrow.clockwise")
-                                        .font(.system(size: min(max(geometry.size.width * 0.02, 14), 18), weight: .semibold))
-                                    Text("Zero Scale")
-                                        .font(.system(size: min(max(geometry.size.width * 0.02, 14), 18), weight: .semibold))
-                                }
-                                .foregroundStyle(.white)
-                                .frame(width: min(max(geometry.size.width * 0.2, 140), 180), 
-                                       height: min(max(geometry.size.height * 0.08, 40), 55))
-                                .background(
-                                    RoundedRectangle(cornerRadius: 25)
-                                        .fill(
-                                            LinearGradient(
-                                                colors: [.blue, .teal],
-                                                startPoint: .leading,
-                                                endPoint: .trailing
+                            HStack(spacing: 10) {
+                                Button(action: {
+                                    viewModel.zeroScale()
+                                }) {
+                                    HStack(spacing: 8) {
+                                        Image(systemName: "arrow.clockwise")
+                                            .font(.system(size: min(max(geometry.size.width * 0.02, 14), 18), weight: .semibold))
+                                        Text("Zero Scale")
+                                            .font(.system(size: min(max(geometry.size.width * 0.02, 14), 18), weight: .semibold))
+                                    }
+                                    .foregroundStyle(.white)
+                                    .frame(width: min(max(geometry.size.width * 0.2, 140), 180), 
+                                           height: min(max(geometry.size.height * 0.08, 40), 55))
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 25)
+                                            .fill(
+                                                LinearGradient(
+                                                    colors: [.blue, .teal],
+                                                    startPoint: .leading,
+                                                    endPoint: .trailing
+                                                )
                                             )
-                                        )
-                                )
+                                    )
+                                }
+                                .buttonStyle(.plain)
+                                .opacity(viewModel.hasTouch ? 1 : 0)
+                                .scaleEffect(viewModel.hasTouch ? 1 : 0.8)
+                                .animation(.spring(response: 0.4, dampingFraction: 0.8), value: viewModel.hasTouch)
+                                
+                                // Reset calibration button - always visible
+                                Button(action: {
+                                    viewModel.resetCalibration()
+                                }) {
+                                    HStack(spacing: 6) {
+                                        Image(systemName: "xmark.circle")
+                                            .font(.system(size: min(max(geometry.size.width * 0.018, 12), 16), weight: .medium))
+                                        Text("Reset")
+                                            .font(.system(size: min(max(geometry.size.width * 0.018, 12), 16), weight: .medium))
+                                    }
+                                    .foregroundStyle(.red)
+                                    .frame(width: min(max(geometry.size.width * 0.12, 80), 100), 
+                                           height: min(max(geometry.size.height * 0.06, 30), 40))
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 20)
+                                            .stroke(.red.opacity(0.5), lineWidth: 1.5)
+                                    )
+                                }
+                                .buttonStyle(.plain)
+                                .opacity(viewModel.zeroOffset != 0 ? 0.7 : 0.3)
+                                .disabled(viewModel.zeroOffset == 0)
                             }
-                            .buttonStyle(.plain)
-                            .opacity(viewModel.hasTouch ? 1 : 0)
-                            .scaleEffect(viewModel.hasTouch ? 1 : 0.8)
-                            .animation(.spring(response: 0.4, dampingFraction: 0.8), value: viewModel.hasTouch)
                         }
                         .frame(height: min(max(geometry.size.height * 0.15, 80), 100)) // Fixed space for button + instruction
                         .frame(maxWidth: .infinity) // Ensure full width for centering

--- a/TrackWeight/ScaleViewModel.swift
+++ b/TrackWeight/ScaleViewModel.swift
@@ -10,12 +10,22 @@ import Combine
 @MainActor
 final class ScaleViewModel: ObservableObject {
     @Published var currentWeight: Float = 0.0
-    @Published var zeroOffset: Float = 0.0
+    @Published var zeroOffset: Float = 0.0 {
+        didSet {
+            // Persist zero offset to UserDefaults when it changes
+            UserDefaults.standard.set(zeroOffset, forKey: "TrackWeight.zeroOffset")
+        }
+    }
     @Published var isListening = false
     @Published var hasTouch = false
     
     private let manager = OMSManager.shared
     private var task: Task<Void, Never>?
+    
+    init() {
+        // Restore saved zero offset from UserDefaults
+        self.zeroOffset = UserDefaults.standard.float(forKey: "TrackWeight.zeroOffset")
+    }
     
     func startListening() {
         if manager.startListening() {
@@ -46,11 +56,16 @@ final class ScaleViewModel: ObservableObject {
         }
     }
     
+    func resetCalibration() {
+        zeroOffset = 0.0
+        // This will automatically persist to UserDefaults via the didSet observer
+    }
+    
     private func processTouchData(_ touchData: [OMSTouchData]) {
         if touchData.isEmpty {
             hasTouch = false
             currentWeight = 0.0
-            zeroOffset = 0.0  // Reset zero when finger is lifted
+            // Do not reset zeroOffset when finger is lifted - preserve calibration
         } else {
             hasTouch = true
             let rawWeight = touchData.first?.pressure ?? 0.0


### PR DESCRIPTION
The core issue was zeroOffset = 0.0 resets the calibration every time you lift your finger. This makes the scale completely unusable because:

1. When you calibrate the scale by pressing "Zero Scale", it sets the zeroOffset
2. But as soon as you lift your finger to place an object, the calibration is lost
3. This defeats the entire purpose of a scale

Additionally, I added:
1. Persistence: The calibration is now saved to UserDefaults, so it persists between app launches
2. Reset function: Added a proper resetCalibration() method for when users actually want to reset
3. Reset button: Added a UI button to reset calibration when needed