### PR TITLE
Add build pipeline for both signed and unsigned builds.

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,128 @@
+# GitHub Actions Workflows
+
+This directory contains GitHub Actions workflows for the TrackWeight project.
+
+## build-and-sign-dmg.yml
+
+This workflow builds, signs (if certificates are provided), and packages the TrackWeight macOS application into a DMG file.
+
+### Features
+
+- **Automated Building**: Builds the Xcode project using the latest stable Xcode
+- **Code Signing**: Supports optional code signing with certificates
+- **DMG Creation**: Creates a professional DMG with proper layout and attribution
+- **Attribution**: Includes proper credits to the original repository (https://github.com/KrishKrosh/TrackWeight)
+- **Release Integration**: Can create GitHub releases with the built DMG
+- **Artifact Upload**: Uploads DMG as a GitHub Actions artifact
+
+### Triggers
+
+The workflow runs on:
+- Git tags starting with 'v' (e.g., v1.0.0)
+- Published releases
+- Manual workflow dispatch
+
+### Setup Instructions
+
+#### Required Secrets (for signed builds)
+
+To enable code signing, add these secrets to your GitHub repository:
+
+1. **BUILD_CERTIFICATE_BASE64**: Base64-encoded Developer ID Application certificate (.p12 file)
+   ```bash
+   base64 -i YourCertificate.p12 | pbcopy
+   ```
+
+2. **P12_PASSWORD**: Password for the .p12 certificate file
+
+3. **BUILD_PROVISION_PROFILE_BASE64**: Base64-encoded provisioning profile (optional for Developer ID)
+   ```bash
+   base64 -i YourProvisioningProfile.mobileprovision | pbcopy
+   ```
+
+#### Setting up Certificates
+
+1. Export your Developer ID Application certificate from Keychain Access as a .p12 file
+2. Convert to base64 and add as `BUILD_CERTIFICATE_BASE64` secret
+3. Add the certificate password as `P12_PASSWORD` secret
+
+#### Unsigned Builds
+
+If you don't have code signing certificates, the workflow will automatically create an unsigned development build. These builds can still be used but may require users to manually allow them in System Preferences.
+
+## build-unsigned-dmg.yml
+
+This workflow specifically builds unsigned development versions of the TrackWeight app without requiring any certificates.
+
+### Features
+
+- **No Certificate Requirements**: Builds completely without code signing
+- **Development Build**: Creates unsigned development builds that work on any Mac
+- **Same DMG Features**: Includes all the same DMG features as the signed version
+- **Clear User Instructions**: Includes instructions for running unsigned apps
+- **Attribution**: Maintains proper credits to the original repository
+
+### Triggers
+
+The workflow runs on:
+- Pushes to main branches and the current working branch
+- Manual workflow dispatch
+
+### Benefits
+
+- **Easy Testing**: Perfect for testing builds without setting up certificates
+- **No Configuration**: Works immediately without any secrets or setup
+- **User-Friendly**: Includes clear instructions for users on how to run unsigned apps
+
+## Choosing the Right Workflow
+
+### Use `build-and-sign-dmg.yml` when:
+- You have Apple Developer certificates
+- You want to distribute signed, trusted builds
+- You're creating official releases
+
+### Use `build-unsigned-dmg.yml` when:
+- You don't have certificates
+- You want to test builds quickly
+- You're developing or experimenting
+- You need a simple build process
+
+If no signing certificates are provided, the workflow will create an unsigned development build that can still be distributed and run locally (users may need to allow it in System Preferences > Security & Privacy).
+
+### Usage
+
+#### Manual Trigger
+1. Go to Actions tab in your GitHub repository
+2. Select "Build and Sign DMG" workflow
+3. Click "Run workflow"
+4. Optionally check "Create a GitHub release" to create a release
+
+#### Automatic Trigger
+1. Create a git tag: `git tag v1.0.0`
+2. Push the tag: `git push origin v1.0.0`
+3. The workflow will automatically build and create a release
+
+### Output
+
+The workflow produces:
+- **DMG file**: TrackWeight-{version}.dmg containing the app and attribution
+- **GitHub Release**: (if triggered by tag or manual release creation)
+- **Artifacts**: DMG file uploaded as GitHub Actions artifact
+
+### Attribution
+
+This workflow ensures proper attribution to the original TrackWeight repository:
+- README.txt file included in DMG with credits
+- Release notes include attribution
+- Links to original repository: https://github.com/KrishKrosh/TrackWeight
+
+## update-homebrew.yml
+
+This workflow automatically updates the Homebrew cask when a new release is published.
+
+### Features
+- Updates version in Homebrew tap repository
+- Automatically triggered on release publication
+- Can be manually triggered with version input
+
+For more information about the original TrackWeight project, visit: https://github.com/KrishKrosh/TrackWeight

--- a/.github/workflows/build-and-sign-dmg.yml
+++ b/.github/workflows/build-and-sign-dmg.yml
@@ -1,0 +1,228 @@
+name: Build and Sign DMG
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - 'copilot/fix-1'  # Enable testing on current working branch
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create a GitHub release'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  APP_NAME: TrackWeight
+  SCHEME: TrackWeight
+  CONFIGURATION: Release
+
+jobs:
+  build-and-sign:
+    runs-on: macos-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+    
+    - name: Import Code-Signing Certificates
+      if: ${{ secrets.BUILD_CERTIFICATE_BASE64 != '' }}
+      uses: Apple-Actions/import-codesign-certs@v2
+      with:
+        p12-file-base64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        p12-password: ${{ secrets.P12_PASSWORD }}
+    
+    - name: Install provisioning profile
+      if: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 != '' }}
+      env:
+        BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+      run: |
+        PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+        echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+        mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+        cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+    
+    - name: Build and Archive App
+      run: |
+        xcodebuild \
+          -project TrackWeight.xcodeproj \
+          -scheme ${{ env.SCHEME }} \
+          -configuration ${{ env.CONFIGURATION }} \
+          -archivePath "$RUNNER_TEMP/${{ env.APP_NAME }}.xcarchive" \
+          archive
+    
+    - name: Export App
+      run: |
+        # Use development export method if no signing certificates are available
+        if [ -z "${{ secrets.BUILD_CERTIFICATE_BASE64 }}" ]; then
+          # Create export options for unsigned build
+          cat > "$RUNNER_TEMP/ExportOptions.plist" << EOF
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>method</key>
+            <string>debugging</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>stripSwiftSymbols</key>
+            <true/>
+            <key>destination</key>
+            <string>export</string>
+            <key>signingCertificate</key>
+            <string>-</string>
+            <key>teamID</key>
+            <string>-</string>
+            <key>uploadBitcode</key>
+            <false/>
+            <key>uploadSymbols</key>
+            <false/>
+        </dict>
+        </plist>
+        EOF
+        else
+          # Use the existing ExportOptions.plist for signed builds
+          cp ExportOptions.plist "$RUNNER_TEMP/ExportOptions.plist"
+        fi
+        
+        xcodebuild \
+          -archivePath "$RUNNER_TEMP/${{ env.APP_NAME }}.xcarchive" \
+          -exportPath "$RUNNER_TEMP/export" \
+          -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \
+          -exportArchive
+    
+    - name: Install create-dmg
+      run: |
+        brew install create-dmg
+    
+    - name: Create README file
+      run: |
+        # Create a README with attribution
+        cat > "$RUNNER_TEMP/export/README.txt" << 'EOF'
+        TrackWeight - MacBook Trackpad Digital Scale
+        
+        This application transforms your MacBook's trackpad into a precise digital weighing scale.
+        
+        CREDITS:
+        Original repository: https://github.com/KrishKrosh/TrackWeight
+        Created by: Krish Shah (@KrishKrosh)
+        
+        This build was created from a fork at: https://github.com/Rohithzr/TrackWeight
+        
+        USAGE:
+        1. Open the scale
+        2. Rest your finger on the trackpad
+        3. While maintaining finger contact, put your object on the trackpad
+        4. Try to put as little pressure on the trackpad while still maintaining contact
+        
+        REQUIREMENTS:
+        - macOS 13.0 or later
+        - MacBook with Force Touch trackpad (2015 or newer MacBook Pro, 2016 or newer MacBook)
+        - App Sandbox must be disabled for trackpad access
+        
+        LICENSE: MIT License
+        
+        For more information, visit the original repository:
+        https://github.com/KrishKrosh/TrackWeight
+        EOF
+    
+    - name: Create DMG
+      run: |
+        # Create DMG with proper attribution to original repository
+        create-dmg \
+          --volname "${{ env.APP_NAME }}" \
+          --volicon "$RUNNER_TEMP/export/${{ env.APP_NAME }}.app/Contents/Resources/AppIcon.icns" \
+          --window-pos 200 120 \
+          --window-size 600 300 \
+          --icon-size 100 \
+          --icon "${{ env.APP_NAME }}.app" 175 120 \
+          --hide-extension "${{ env.APP_NAME }}.app" \
+          --app-drop-link 425 120 \
+          --hdiutil-quiet \
+          "$RUNNER_TEMP/${{ env.APP_NAME }}.dmg" \
+          "$RUNNER_TEMP/export/"
+    
+    - name: Get version info
+      id: version_info
+      run: |
+        if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          VERSION=${GITHUB_REF#refs/tags/}
+        else
+          VERSION=$(date +%Y%m%d-%H%M%S)
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "dmg_name=${{ env.APP_NAME }}-$VERSION.dmg" >> $GITHUB_OUTPUT
+    
+    - name: Rename DMG with version
+      run: |
+        mv "$RUNNER_TEMP/${{ env.APP_NAME }}.dmg" "$RUNNER_TEMP/${{ steps.version_info.outputs.dmg_name }}"
+    
+    - name: Upload DMG as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.version_info.outputs.dmg_name }}
+        path: ${{ runner.temp }}/${{ steps.version_info.outputs.dmg_name }}
+        retention-days: 30
+    
+    - name: Create Release
+      if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true')
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.version_info.outputs.version }}
+        name: ${{ env.APP_NAME }} ${{ steps.version_info.outputs.version }}
+        body: |
+          # TrackWeight ${{ steps.version_info.outputs.version }}
+          
+          Transform your MacBook's trackpad into a precise digital weighing scale!
+          
+          ## Credits
+          **Original repository:** https://github.com/KrishKrosh/TrackWeight  
+          **Created by:** Krish Shah (@KrishKrosh)
+          
+          This build is from the fork at https://github.com/Rohithzr/TrackWeight
+          
+          ## Installation
+          1. Download the DMG file below
+          2. Open the DMG and drag TrackWeight.app to your Applications folder
+          3. Run the app and follow the setup instructions
+          
+          ## Requirements
+          - macOS 13.0 or later
+          - MacBook with Force Touch trackpad (2015 or newer MacBook Pro, 2016 or newer MacBook)
+          
+          ## Usage
+          1. Open the scale
+          2. Rest your finger on the trackpad
+          3. While maintaining finger contact, put your object on the trackpad
+          4. Apply minimal pressure while maintaining contact to get the weight
+          
+          For more information, visit the [original repository](https://github.com/KrishKrosh/TrackWeight).
+        files: |
+          ${{ runner.temp }}/${{ steps.version_info.outputs.dmg_name }}
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Summary
+      run: |
+        echo "## Build Summary" >> $GITHUB_STEP_SUMMARY
+        echo "✅ Successfully built and packaged TrackWeight DMG" >> $GITHUB_STEP_SUMMARY
+        echo "📦 DMG file: ${{ steps.version_info.outputs.dmg_name }}" >> $GITHUB_STEP_SUMMARY
+        echo "🔗 Original repository: https://github.com/KrishKrosh/TrackWeight" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "The DMG includes:" >> $GITHUB_STEP_SUMMARY
+        echo "- TrackWeight.app (signed if certificates provided)" >> $GITHUB_STEP_SUMMARY
+        echo "- README.txt with attribution and usage instructions" >> $GITHUB_STEP_SUMMARY
+        echo "- Proper credits to the original repository" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-unsigned-dmg.yml
+++ b/.github/workflows/build-unsigned-dmg.yml
@@ -1,0 +1,218 @@
+name: Build Unsigned DMG
+
+on:
+  push:
+    branches:
+      - 'copilot/fix-1'  # Enable testing on current working branch
+      - main
+      - develop
+  workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create a GitHub release'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  APP_NAME: TrackWeight
+  SCHEME: TrackWeight
+  CONFIGURATION: Release
+
+jobs:
+  build-unsigned:
+    runs-on: macos-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+    
+    - name: Build and Archive App (Unsigned)
+      run: |
+        # Build without code signing
+        xcodebuild \
+          -project TrackWeight.xcodeproj \
+          -scheme ${{ env.SCHEME }} \
+          -configuration ${{ env.CONFIGURATION }} \
+          -archivePath "$RUNNER_TEMP/${{ env.APP_NAME }}.xcarchive" \
+          CODE_SIGN_IDENTITY="" \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGNING_ALLOWED=NO \
+          DEVELOPMENT_TEAM=${{ secrets.DEVELOPMENT_TEAM }} \
+          archive
+    
+    - name: Export App (Unsigned)
+      run: |
+        # Create export options for unsigned build
+        cat > "$RUNNER_TEMP/UnsignedExportOptions.plist" << EOF
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>method</key>
+            <string>debugging</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>stripSwiftSymbols</key>
+            <true/>
+            <key>destination</key>
+            <string>export</string>
+            <key>signingCertificate</key>
+            <string>-</string>
+            <key>teamID</key>
+            <string>-</string>
+            <key>uploadBitcode</key>
+            <false/>
+            <key>uploadSymbols</key>
+            <false/>
+        </dict>
+        </plist>
+        EOF
+        
+        xcodebuild \
+          -archivePath "$RUNNER_TEMP/${{ env.APP_NAME }}.xcarchive" \
+          -exportPath "$RUNNER_TEMP/export" \
+          -exportOptionsPlist "$RUNNER_TEMP/UnsignedExportOptions.plist" \
+          -exportArchive
+    
+    - name: Install create-dmg
+      run: |
+        brew install create-dmg
+    
+    - name: Create README file
+      run: |
+        # Create a README with attribution
+        cat > "$RUNNER_TEMP/export/README.txt" << 'EOF'
+        TrackWeight - MacBook Trackpad Digital Scale (UNSIGNED DEVELOPMENT BUILD)
+        
+        This application transforms your MacBook's trackpad into a precise digital weighing scale.
+        
+        ⚠️  IMPORTANT: This is an unsigned development build. You may need to:
+        1. Right-click the app and select "Open" the first time
+        2. Go to System Preferences > Security & Privacy > General and click "Open Anyway"
+        3. Allow the app to access your trackpad in Privacy settings
+        
+        CREDITS:
+        Original repository: https://github.com/KrishKrosh/TrackWeight
+        Created by: Krish Shah (@KrishKrosh)
+        
+        This build was created from a fork at: https://github.com/Rohithzr/TrackWeight
+        
+        USAGE:
+        1. Open the scale
+        2. Rest your finger on the trackpad
+        3. While maintaining finger contact, put your object on the trackpad
+        4. Try to put as little pressure on the trackpad while still maintaining contact
+        
+        REQUIREMENTS:
+        - macOS 13.0 or later
+        - MacBook with Force Touch trackpad (2015 or newer MacBook Pro, 2016 or newer MacBook)
+        - App Sandbox must be disabled for trackpad access
+        
+        LICENSE: MIT License
+        
+        For more information, visit the original repository:
+        https://github.com/KrishKrosh/TrackWeight
+        EOF
+    
+    - name: Create DMG
+      run: |
+        # Create DMG with proper attribution to original repository
+        create-dmg \
+          --volname "${{ env.APP_NAME }}" \
+          --volicon "$RUNNER_TEMP/export/${{ env.APP_NAME }}.app/Contents/Resources/AppIcon.icns" \
+          --window-pos 200 120 \
+          --window-size 600 300 \
+          --icon-size 100 \
+          --icon "${{ env.APP_NAME }}.app" 175 120 \
+          --hide-extension "${{ env.APP_NAME }}.app" \
+          --app-drop-link 425 120 \
+          --hdiutil-quiet \
+          "$RUNNER_TEMP/${{ env.APP_NAME }}.dmg" \
+          "$RUNNER_TEMP/export/"
+    
+    - name: Get version info
+      id: version_info
+      run: |
+        if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          VERSION=${GITHUB_REF#refs/tags/}
+        else
+          VERSION=$(date +%Y%m%d-%H%M%S)
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "dmg_name=${{ env.APP_NAME }}-unsigned-$VERSION.dmg" >> $GITHUB_OUTPUT
+    
+    - name: Rename DMG with version
+      run: |
+        mv "$RUNNER_TEMP/${{ env.APP_NAME }}.dmg" "$RUNNER_TEMP/${{ steps.version_info.outputs.dmg_name }}"
+    
+    - name: Upload DMG as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.version_info.outputs.dmg_name }}
+        path: ${{ runner.temp }}/${{ steps.version_info.outputs.dmg_name }}
+        retention-days: 30
+    
+    - name: Create Release
+      if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true')
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.version_info.outputs.version }}
+        name: ${{ env.APP_NAME }} ${{ steps.version_info.outputs.version }} (Unsigned)
+        body: |
+          # TrackWeight ${{ steps.version_info.outputs.version }} (Unsigned Development Build)
+          
+          Transform your MacBook's trackpad into a precise digital weighing scale!
+          
+          **⚠️ This is an unsigned development build** - you may need to allow it in System Preferences.
+          
+          ## Credits
+          **Original repository:** https://github.com/KrishKrosh/TrackWeight  
+          **Created by:** Krish Shah (@KrishKrosh)
+          
+          This build is from the fork at https://github.com/Rohithzr/TrackWeight
+          
+          ## Installation
+          1. Download the DMG file below
+          2. Open the DMG and drag TrackWeight.app to your Applications folder
+          3. Right-click the app and select "Open" the first time
+          4. Go to System Preferences > Security & Privacy if prompted and click "Open Anyway"
+          
+          ## Requirements
+          - macOS 13.0 or later
+          - MacBook with Force Touch trackpad (2015 or newer MacBook Pro, 2016 or newer MacBook)
+          
+          ## Usage
+          1. Open the scale
+          2. Rest your finger on the trackpad
+          3. While maintaining finger contact, put your object on the trackpad
+          4. Apply minimal pressure while maintaining contact to get the weight
+          
+          For more information, visit the [original repository](https://github.com/KrishKrosh/TrackWeight).
+        files: |
+          ${{ runner.temp }}/${{ steps.version_info.outputs.dmg_name }}
+        draft: false
+        prerelease: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Summary
+      run: |
+        echo "## Build Summary" >> $GITHUB_STEP_SUMMARY
+        echo "✅ Successfully built and packaged unsigned TrackWeight DMG" >> $GITHUB_STEP_SUMMARY
+        echo "📦 DMG file: ${{ steps.version_info.outputs.dmg_name }}" >> $GITHUB_STEP_SUMMARY
+        echo "⚠️  This is an unsigned development build" >> $GITHUB_STEP_SUMMARY
+        echo "🔗 Original repository: https://github.com/KrishKrosh/TrackWeight" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "The DMG includes:" >> $GITHUB_STEP_SUMMARY
+        echo "- TrackWeight.app (unsigned development build)" >> $GITHUB_STEP_SUMMARY
+        echo "- README.txt with attribution and usage instructions" >> $GITHUB_STEP_SUMMARY
+        echo "- Proper credits to the original repository" >> $GITHUB_STEP_SUMMARY
+        echo "- Instructions for running unsigned apps on macOS" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -35,12 +35,31 @@ The key insight is that trackpad pressure events are only generated when there's
 brew install --cask krishkrosh/apps/trackweight
 ```
 
-### Option 2: Build from Source
+### Option 2: Download DMG
+
+1. Go to the [Releases](https://github.com/Rohithzr/TrackWeight/releases) page
+2. Download the latest TrackWeight DMG file
+3. Open the DMG and drag TrackWeight.app to your Applications folder
+4. Run the application (you may need to allow it in System Preferences > Security & Privacy for unsigned builds)
+
+### Option 3: Build from Source
 
 1. Clone this repository
 2. Open `TrackWeight.xcodeproj` in Xcode
 3. Disable App Sandbox in the project settings (required for trackpad access)
 4. Build and run the application
+
+## Automated Builds
+
+This repository includes a GitHub Actions workflow that automatically builds and packages the application into a signed DMG file. The workflow:
+
+- Builds the Xcode project using the latest stable Xcode
+- Signs the application (if signing certificates are configured)
+- Creates a professional DMG with proper attribution
+- Uploads the DMG as a release artifact
+- Creates GitHub releases for tagged versions
+
+For more information about setting up the build pipeline, see [.github/workflows/README.md](.github/workflows/README.md).
 
 ### Calibration Process
 
@@ -73,6 +92,15 @@ This project relies heavily on the excellent work by **Takuto Nakamura** ([@Kyom
 - Detailed touch data including position, pressure, angle, and density
 - Thread-safe async/await support for touch event streams
 - Touch state tracking and comprehensive sensor data
+
+## Credits and Attribution
+
+**🙏 Full credit goes to the original TrackWeight project:**
+- **Original Repository**: https://github.com/KrishKrosh/TrackWeight
+- **Creator**: Krish Shah ([@KrishKrosh](https://github.com/KrishKrosh))
+- **Original Tweet**: https://x.com/KrishRShah/status/1947186835811193330
+
+This repository is a fork that adds automated DMG build and signing pipelines to make distribution easier. All core functionality and the brilliant idea of using trackpad sensors for weighing comes from the original project.
 
 ## License
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,47 @@
+# Scripts
+
+This directory contains helper scripts for the TrackWeight project.
+
+## setup-signing.sh
+
+A helper script to set up code signing certificates for automated DMG builds.
+
+### Usage
+
+```bash
+./scripts/setup-signing.sh
+```
+
+### What it does
+
+1. **Guides you through certificate export**: Provides step-by-step instructions to export your Developer ID Application certificate from Keychain Access
+2. **Encodes certificates**: Converts your .p12 certificate file to base64 format required for GitHub Secrets
+3. **Generates secret values**: Provides the exact values you need to add as GitHub repository secrets
+4. **Optional provisioning profile**: Handles provisioning profile encoding if needed
+
+### Prerequisites
+
+- macOS (required for Keychain Access and signing tools)
+- Valid Apple Developer ID Application certificate
+- Access to GitHub repository settings to add secrets
+
+### Output
+
+The script will generate the values for these GitHub repository secrets:
+- `BUILD_CERTIFICATE_BASE64`: Base64-encoded .p12 certificate
+- `P12_PASSWORD`: Certificate password
+- `BUILD_PROVISION_PROFILE_BASE64`: Base64-encoded provisioning profile (optional)
+
+### Adding Secrets to GitHub
+
+1. Go to your GitHub repository
+2. Navigate to Settings > Secrets and variables > Actions
+3. Click "New repository secret"
+4. Add each secret with the name and value provided by the script
+
+### Attribution
+
+This script is part of the enhanced TrackWeight fork that adds automated build pipelines.
+
+**Original TrackWeight project**: https://github.com/KrishKrosh/TrackWeight  
+**Created by**: Krish Shah (@KrishKrosh)

--- a/scripts/setup-signing.sh
+++ b/scripts/setup-signing.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# setup-signing.sh
+# Helper script to set up code signing certificates for TrackWeight DMG builds
+# 
+# This script helps you prepare the necessary secrets for GitHub Actions
+# to build signed DMG files.
+
+set -e
+
+echo "🔐 TrackWeight Code Signing Setup"
+echo "=================================="
+echo ""
+echo "This script helps you set up code signing for automated DMG builds."
+echo "You'll need a valid Apple Developer ID Application certificate."
+echo ""
+
+# Check if we're on macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "❌ This script must be run on macOS to access Keychain and signing tools."
+    exit 1
+fi
+
+# Function to encode file to base64
+encode_file() {
+    local file_path="$1"
+    if [[ -f "$file_path" ]]; then
+        base64 -i "$file_path"
+    else
+        echo "❌ File not found: $file_path"
+        return 1
+    fi
+}
+
+echo "Step 1: Export your Developer ID Application certificate"
+echo "--------------------------------------------------------"
+echo "1. Open Keychain Access"
+echo "2. Find your 'Developer ID Application' certificate"
+echo "3. Right-click and select 'Export'"
+echo "4. Save as .p12 format with a password"
+echo ""
+read -p "Enter the path to your exported .p12 certificate: " cert_path
+
+if [[ ! -f "$cert_path" ]]; then
+    echo "❌ Certificate file not found: $cert_path"
+    exit 1
+fi
+
+echo ""
+read -s -p "Enter the password for your .p12 certificate: " cert_password
+echo ""
+
+echo ""
+echo "Step 2: Encoding certificate for GitHub Secrets"
+echo "----------------------------------------------"
+
+# Encode the certificate
+echo "Encoding certificate..."
+cert_base64=$(encode_file "$cert_path")
+
+if [[ -z "$cert_base64" ]]; then
+    echo "❌ Failed to encode certificate"
+    exit 1
+fi
+
+echo "✅ Certificate encoded successfully"
+
+echo ""
+echo "Step 3: GitHub Repository Secrets"
+echo "--------------------------------"
+echo "Add these secrets to your GitHub repository:"
+echo "(Go to Settings > Secrets and variables > Actions)"
+echo ""
+echo "1. Secret name: BUILD_CERTIFICATE_BASE64"
+echo "   Value: (copy the text below)"
+echo ""
+echo "$cert_base64"
+echo ""
+echo "2. Secret name: P12_PASSWORD"
+echo "   Value: $cert_password"
+echo ""
+
+# Check for provisioning profile (optional for Developer ID)
+echo "Step 4: Provisioning Profile (Optional)"
+echo "--------------------------------------"
+read -p "Do you have a provisioning profile to include? (y/n): " include_profile
+
+if [[ "$include_profile" =~ ^[Yy]$ ]]; then
+    read -p "Enter the path to your .mobileprovision file: " profile_path
+    
+    if [[ -f "$profile_path" ]]; then
+        profile_base64=$(encode_file "$profile_path")
+        echo ""
+        echo "3. Secret name: BUILD_PROVISION_PROFILE_BASE64"
+        echo "   Value: (copy the text below)"
+        echo ""
+        echo "$profile_base64"
+    else
+        echo "❌ Provisioning profile not found: $profile_path"
+    fi
+else
+    echo "📝 Skipping provisioning profile (Developer ID usually doesn't need one)"
+fi
+
+echo ""
+echo "🎉 Setup Complete!"
+echo "================="
+echo ""
+echo "Next steps:"
+echo "1. Add the secrets to your GitHub repository"
+echo "2. Create a git tag to trigger the build: git tag v1.0.0 && git push origin v1.0.0"
+echo "3. Or manually trigger the workflow from the Actions tab"
+echo ""
+echo "The workflow will:"
+echo "- Build and sign your app with the provided certificate"
+echo "- Create a professional DMG with attribution to the original repo"
+echo "- Upload the DMG as a release artifact"
+echo ""
+echo "Original TrackWeight project: https://github.com/KrishKrosh/TrackWeight"


### PR DESCRIPTION
Add macOS DMG Build Workflows

This PR introduces two GitHub Actions workflows for building the TrackWeight macOS application into a DMG file:

🛠️ Added Files
	•	build-and-sign-dmg.yml
	•	build-unsigned-dmg.yml

___

build-and-sign-dmg.yml

A comprehensive workflow that builds, signs (if certificates are provided), and packages the app into a production-ready DMG file.

✨ Features
	•	Automated building using latest Xcode
	•	Optional code signing using Apple Developer certificates
	•	Professional DMG creation with custom layout and attribution
	•	Uploads DMG as artifact and (optionally) attaches it to GitHub releases
	•	Attribution to original repo: https://github.com/KrishKrosh/TrackWeight

⚙️ Triggers
	•	Git tags starting with v (e.g., v1.0.0)
	•	Published releases
	•	Manual dispatch

🔐 Required Secrets (for signing)
	•	BUILD_CERTIFICATE_BASE64
	•	P12_PASSWORD
	•	BUILD_PROVISION_PROFILE_BASE64 (optional)

If no certificates are provided, it will fall back to an unsigned development build.

___

build-unsigned-dmg.yml

A lightweight workflow for unsigned development builds. No certificates required.

✨ Features
	•	Builds without Apple Developer certificates
	•	Produces unsigned development DMG
	•	Same DMG features and attribution as the signed version
	•	Useful for testing or local development

⚙️ Triggers
	•	Pushes to main or current working branch
	•	Manual dispatch

___

✅ When to Use Which

Workflow	Use Case
build-and-sign-dmg.yml	You have certificates and want signed releases
build-unsigned-dmg.yml	You’re testing or developing without certificates


___

🧪 Usage Instructions

Manual
	•	Navigate to the Actions tab
	•	Select the desired workflow
	•	Click Run workflow

Automatic

git tag v1.0.0
git push origin v1.0.0


___

📦 Output
	•	TrackWeight-{version}.dmg with app and attribution
	•	GitHub Release (if applicable)
	•	GitHub Actions artifact with DMG file
