### PR TITLE
Added a note regarding the "default to Touchbar" issue.

### DIFF
--- a/TrackWeight/ContentView.swift
+++ b/TrackWeight/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
             HomeView {
                 showHomePage = false
             }
-            .frame(minWidth: 700, minHeight: 500)
+            .frame(minWidth: 700, minHeight: 700)
         } else {
             TabView(selection: $selectedTab) {
                 TrackWeightView()
@@ -38,7 +38,7 @@ struct ContentView: View {
                     }
                     .tag(2)
             }
-            .frame(minWidth: 700, minHeight: 500)
+            .frame(minWidth: 700, minHeight: 700)
         }
     }
 }

--- a/TrackWeight/HomeView.swift
+++ b/TrackWeight/HomeView.swift
@@ -74,29 +74,30 @@ struct HomeView: View {
             }
             
             // Select a device first
-            VStack(spacing: 20) {
-                // Device Card
-                SettingsCard {
-                    VStack(spacing: 12) {
-                        // Status Row
-                        HStack {
-                            HStack(spacing: 12) {
-                                Text("Verify Device Selection")
-                                    .font(.headline)
-                                    .fontWeight(.medium)
-                            }
-                            
-                            Spacer()
-                            
-                            if !viewModel.availableDevices.isEmpty {
+            if viewModel.availableDevices.count > 1 {
+                VStack(spacing: 20) {
+                    // Device Card
+                    SettingsCard {
+                        VStack(spacing: 12) {
+                            // Status Row
+                            HStack {
+                                HStack(spacing: 12) {
+                                    Text("Verify Device Selection")
+                                        .font(.headline)
+                                        .fontWeight(.medium)
+                                }
+                                
+                                Spacer()
+                                
+                                
                                 Text("\(viewModel.availableDevices.count) device\(viewModel.availableDevices.count == 1 ? "" : "s")")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
+                                
                             }
-                        }
-                        
-                        // Device Selector
-                        if !viewModel.availableDevices.isEmpty {
+                            
+                            // Device Selector
+                            
                             VStack(alignment: .leading, spacing: 12) {
                                 HStack {
                                     Image(systemName: "exclamationmark.triangle")
@@ -129,19 +130,12 @@ struct HomeView: View {
                                 
                             }
                             .frame(width: 450)
-                        } else {
-                            HStack {
-                                Text("No devices available")
-                                    .foregroundColor(.secondary)
-                                Spacer()
-                            }
                         }
                     }
                 }
+                .frame(maxWidth: 480)
+                .padding(.horizontal, 40)
             }
-            .frame(maxWidth: 480)
-            .padding(.horizontal, 40)
-            
             // Begin button
             Button(action: onBegin) {
                 HStack(spacing: 10) {

--- a/TrackWeight/HomeView.swift
+++ b/TrackWeight/HomeView.swift
@@ -4,9 +4,11 @@
 //
 
 import SwiftUI
+import OpenMultitouchSupport
 
 struct HomeView: View {
     let onBegin: () -> Void
+    @StateObject private var viewModel = ContentViewModel()
     
     var body: some View {
         VStack(spacing: 40) {
@@ -71,7 +73,74 @@ struct HomeView: View {
                 .frame(maxWidth: 500)
             }
             
-            Spacer()
+            // Select a device first
+            VStack(spacing: 20) {
+                // Device Card
+                SettingsCard {
+                    VStack(spacing: 12) {
+                        // Status Row
+                        HStack {
+                            HStack(spacing: 12) {
+                                Text("Verify Device Selection")
+                                    .font(.headline)
+                                    .fontWeight(.medium)
+                            }
+                            
+                            Spacer()
+                            
+                            if !viewModel.availableDevices.isEmpty {
+                                Text("\(viewModel.availableDevices.count) device\(viewModel.availableDevices.count == 1 ? "" : "s")")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        
+                        // Device Selector
+                        if !viewModel.availableDevices.isEmpty {
+                            VStack(alignment: .leading, spacing: 12) {
+                                HStack {
+                                    Image(systemName: "exclamationmark.triangle")
+                                        .font(.system(size: 16, weight: .medium))
+                                        .font(.caption)
+                                        .foregroundColor(.orange)
+                                    Text("OMS may default to the Touch Bar on Macs equipped with it. You can change the selected device in the settings tab. Please ensure you've selected the correct trackpad.")
+                                        .font(.system(size: 12, weight: .medium))
+                                        .foregroundColor(.orange)
+                                }
+                                .padding(.horizontal)
+                                HStack {
+                                    Picker("", selection: Binding(
+                                        get: { viewModel.selectedDevice },
+                                        set: { device in
+                                            if let device = device {
+                                                viewModel.selectDevice(device)
+                                            }
+                                        }
+                                    )) {
+                                        ForEach(viewModel.availableDevices, id: \.self) { device in
+                                            Text(device.deviceName)
+                                                .tag(device as OMSDeviceInfo?)
+                                        }
+                                    }
+                                    .pickerStyle(MenuPickerStyle())
+                                    
+                                    Spacer()
+                                }
+                                
+                            }
+                            .frame(width: 450)
+                        } else {
+                            HStack {
+                                Text("No devices available")
+                                    .foregroundColor(.secondary)
+                                Spacer()
+                            }
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: 480)
+            .padding(.horizontal, 40)
             
             // Begin button
             Button(action: onBegin) {
@@ -99,7 +168,7 @@ struct HomeView: View {
             .scaleEffect(1.0)
             .animation(.spring(response: 0.3, dampingFraction: 0.8), value: true)
             .padding(.vertical, 10)
-
+            
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
The recent issue regarding default selection of "touchbar" on macbooks was quite frustrating and confusing for me, therefore this leaves us with two options.

1. Find a way to differentiate between the built-in input devices and filter out touch bars or magic mouses (weighing/pressure mechanism does not work as expected with magic mouse as well).

2. Let people know about the default to "touchbar" behavior beforehand.

---

I looked around for a solution to differentiate between these devices but it seems the OMS library does not provide sufficient support for this purpose.

Meanwhile I have added a note and a way for user to choose the correct device beforehand.

---
<img width="1036" height="834" alt="Screenshot 2025-07-27 at 9 43 25 PM" src="https://github.com/user-attachments/assets/de75e965-072d-4532-9a04-6e22e6a73d3b" />

