### PR TITLE
Update ScaleViewModel.swift - removed "no negatives" blocker

### DIFF
--- a/TrackWeight/ScaleViewModel.swift
+++ b/TrackWeight/ScaleViewModel.swift
@@ -55,7 +55,7 @@ final class ScaleViewModel: ObservableObject {
         } else {
             hasTouch = true
             rawWeight = touchData.first?.pressure ?? 0.0
-            currentWeight = max(0, rawWeight - zeroOffset)
+            currentWeight = ( rawWeight - zeroOffset)
         }
     }
     


### PR DESCRIPTION
I removed the part of this code that made it make all numbers less than 0, equal 0
<img width="1800" height="1010" alt="Screenshot 2026-07-05 at 6 30 01 PM" src="https://github.com/user-attachments/assets/a83ba032-4094-4784-905b-3dddbb1d4006" />
